### PR TITLE
Update simple-flask-azd README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,29 @@ The most basic Flask "hello world" application as an AZD template ready for Azur
 
 ## Usage
 
-Install AZD and use the `azd up` command to clone and deploy this repository. Then make changes to app.py and run `azd deploy` again to update your changes. 
+1. Install AZD and run the following command to initialize the project.
 
-```console
-$ azd up -t tonybaloney/simple-flask-azd
-
-Initializing a new project (azd init)
-
-...
-
-Deploying services (azd deploy)
-
-  (✓) Done: Deploying service web
-  - Endpoint: https://web-example-12345.azurewebsites.net/
-
-SUCCESS: Your Azure app has been deployed!
+```bash
+azd init --template tonybaloney/simple-flask-azd
 ```
+
+This command will clone the code to your current folder and prompt you for the following information:
+
+- `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
+
+2. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+
+```bash
+azd up
+```
+
+This command will prompt you for the following information:
+- `Azure Location`: The Azure location where your resources will be deployed.
+- `Azure Subscription`: The Azure Subscription where your resources will be deployed.
+
+> NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
+
+3. Then make changes to app.py and run `azd deploy` again to update your changes.
 
 ## Notes
 


### PR DESCRIPTION
Update simple-flask-azd README to use `azd init` and `azd up` instead of `azd up --template` according to https://github.com/Azure/azure-dev/issues/1769.

@jongio, @rajeshkamal5050, @tonybaloney for notification.